### PR TITLE
Revert "Bump django from 4.1.8 to 4.2.1"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ xmltodict==0.13.0  # https://github.com/martinblech/xmltodict.git
 
 # Django
 # ------------------------------------------------------------------------------
-django==4.2.1  # pyup: < 4.0  # https://www.djangoproject.com/
+django==4.1.8  # pyup: < 4.0  # https://www.djangoproject.com/
 django-environ==0.10.0  # https://github.com/joke2k/django-environ
 django-model-utils==4.3.1  # https://github.com/jazzband/django-model-utils
 django-allauth==0.54.0  # https://github.com/pennersr/django-allauth


### PR DESCRIPTION
wagtail 4.2.2 depends on Django<4.2 and >=3.2
Reverts scieloorg/core#207