### PR TITLE
Evita problema de IntegrityError ao criar / obter XMLIssue e XMLJournal e algumas melhorias

### DIFF
--- a/pid_provider/xml_sps_adapter.py
+++ b/pid_provider/xml_sps_adapter.py
@@ -152,6 +152,10 @@ class PidProviderXMLAdapter:
             params["main_doi__iexact"] = params["main_doi"]
         except KeyError:
             pass
+        try:
+            params["pkg_name__iexact"] = params["pkg_name"]
+        except KeyError:
+            pass
 
     @property
     def query_list(self):

--- a/xmlsps/wagtail_hooks.py
+++ b/xmlsps/wagtail_hooks.py
@@ -29,7 +29,6 @@ class XMLSPSAdmin(ModelAdmin):
     )
     list_filter = (
         "is_published",
-        "xml_journal",
     )
     search_fields = (
         "pid_v3",


### PR DESCRIPTION
#### O que esse PR faz?
Evita problema de IntegrityError ao criar / obter XMLIssue e XMLJournal

```
<class 'django.db.utils.IntegrityError'>
duplicate key value violates unique constraint "xmlsps_xmlissue_journal_id_pub_year_volu_acd3d48b_uniq" DETAIL: Key (journal_id, pub_year, volume, number, suppl)=(4, 2017, 89, 1, 0) already exists.
```

#### Onde a revisão poderia começar?
por commits 

#### Como este poderia ser testado manualmente?

```console
python manage.py runscript provide_pid_for_opac_xmls --script-args adm begin_date end_date limit pages
```
sendo:
- begin_date e end_date no formato YYYY-MM-DD
- limit - quantidade por requisição
- pages - quantidade de páginas a consultar, se quiser impor um limite de requisições, caso contrário as consultas irão até o final

```console
python manage.py runscript provide_pid_for_am_xmls --script-args adm
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
