### PR TITLE
Adicionar suporte para  AutoCompletePanel em todos os campos Many-to-Many e ForeignKey

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -202,7 +202,7 @@ class ArticleFunding(CommonControlField):
 
     panels = [
         FieldPanel("award_id"),
-        FieldPanel("funding_source"),
+        AutocompletePanel("funding_source"),
     ]
 
     def __unicode__(self):
@@ -317,6 +317,11 @@ class ArticleHistory(CommonControlField):
         FlexibleDate, null=True, blank=True, on_delete=models.SET_NULL
     )
 
+    panels = [
+        AutocompletePanel("event_type"),
+        AutocompletePanel("date"),
+    ]
+
     class Meta:
         indexes = [
             models.Index(
@@ -393,6 +398,11 @@ class ArticleCount(CommonControlField):
         blank=True,
     )
 
+    panels = [
+        AutocompletePanel("count_type"),
+        AutocompletePanel("language")
+    ]
+
     class Meta:
         indexes = [
             models.Index(
@@ -431,6 +441,12 @@ class SubArticle(models.Model):
     article_type = models.ForeignKey(
         "ArticleType", on_delete=models.SET_NULL, null=True, blank=True
     )
+
+    panels = [
+        AutocompletePanel("titles"),
+        AutocompletePanel("article"),
+        AutocompletePanel("article_type"),
+    ]
 
     class Meta:
         verbose_name = _("SubArticle")

--- a/book/models.py
+++ b/book/models.py
@@ -114,9 +114,9 @@ class Book(CommonControlField, ClusterableModel):
         FieldPanel("doi"),
         FieldPanel("identifier"),
         FieldPanel("year"),
-        FieldPanel("language"),
-        FieldPanel("location"),
-        FieldPanel("institution"),
+        AutocompletePanel("language"),
+        AutocompletePanel("location"),
+        AutocompletePanel("institution"),
         InlinePanel("rec_raws", label="Rec Raws"),
     ]
 
@@ -217,6 +217,12 @@ class Chapter(Orderable, CommonControlField):
         blank=True,
         on_delete=models.SET_NULL,
     )
+
+    panels = [
+        FieldPanel("title"),
+        FieldPanel("publication_date"),
+        AutocompletePanel("language"),
+    ]
 
     class Meta:
         verbose_name = _("Chapter")

--- a/book/sources/oai_books.py
+++ b/book/sources/oai_books.py
@@ -124,6 +124,7 @@ def get_or_create_researchers(researchers):
         obj = Researcher.get_or_create(
             given_names=researcher.get("given_names"),
             last_name=researcher.get("surname"),
+            declared_name=researcher.get("declared_name"),
             suffix=None,
             orcid=None,
             lattes=None,

--- a/collection/models.py
+++ b/collection/models.py
@@ -55,6 +55,11 @@ class Collection(CommonControlField):
     is_active = models.BooleanField(_("Is active"), null=True, blank=True)
     foundation_date = models.DateField(_("Foundation data"), null=True, blank=True)
 
+    autocomplete_search_field = "main_name"
+
+    def autocomplete_label(self):
+        return str(self)
+
     panels = [
         FieldPanel("acron3"),
         FieldPanel("acron2"),

--- a/collection/models.py
+++ b/collection/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext as _
 from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField, TextWithLang
@@ -9,6 +10,11 @@ from . import choices
 
 
 class CollectionName(TextWithLang):
+    autocomplete_search_filter = "text"
+
+    def autocomplete_label(self):
+        return str(self)
+
     @property
     def data(self):
         d = {
@@ -54,7 +60,7 @@ class Collection(CommonControlField):
         FieldPanel("acron2"),
         FieldPanel("code"),
         FieldPanel("domain"),
-        FieldPanel("name"),
+        AutocompletePanel("name"),
         FieldPanel("main_name"),
         FieldPanel("status"),
         FieldPanel("has_analytics"),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -263,7 +263,7 @@ FIXTURE_DIRS = (str(APPS_DIR / "fixtures"),)
 # https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-httponly
 SESSION_COOKIE_HTTPONLY = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-httponly
-CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = False
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-browser-xss-filter
 SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,6 +18,7 @@ from core.search_site import views as search_views  # noqa isort:skip
 urlpatterns = [
     path("", TemplateView.as_view(template_name="home/home_page.html"), name="home"),
     # Django Admin, use {% url "admin:index" %}
+    path("admin/autocomplete/", include(autocomplete_admin_urls)),
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
     # Wagtail Admin
     path(settings.WAGTAIL_ADMIN_URL, include(wagtailadmin_urls)),
@@ -48,7 +49,6 @@ urlpatterns += i18n_patterns(
     # Index search
     re_path(r"^search/", include("search.urls")),
     # User management
-    path("admin/autocomplete/", include(autocomplete_admin_urls)),
     path("api/v2/", api_router.urls),
     path("users/", include("core.users.urls", namespace="users")),
     path("i18n/", include("django.conf.urls.i18n")),

--- a/core/models.py
+++ b/core/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.utils.translation import gettext as _
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
@@ -24,6 +25,11 @@ class Gender(index.Indexed, models.Model):
     code = models.CharField(_("Code"), max_length=5, null=True, blank=True)
 
     gender = models.CharField(_("Sex"), max_length=50, null=True, blank=True)
+
+    autocomplete_search_filter = "code"
+
+    def autocomplete_label(self):
+        return str(self)
 
     panels = [
         FieldPanel("code"),
@@ -97,6 +103,7 @@ class Language(CommonControlField):
     code2 = models.TextField(_("Language code 2"), blank=True, null=True)
     
     autocomplete_search_field = "code2"
+    
     def autocomplete_label(self):
         return str(self)
     
@@ -144,7 +151,9 @@ class TextWithLang(models.Model):
         blank=True,
     )
 
-    panels = [FieldPanel("text"), FieldPanel("language")]
+    panels = [
+        FieldPanel("text"), 
+        AutocompletePanel("language")]
 
     class Meta:
         abstract = True
@@ -162,7 +171,7 @@ class RichTextWithLang(models.Model):
     )
 
     panels = [
-        FieldPanel("language"),
+        AutocompletePanel("language"),
         FieldPanel("rich_text"),
         FieldPanel("plain_text"),
     ]
@@ -203,6 +212,13 @@ class License(CommonControlField):
     def autocomplete_label(self):
         return str(self.license_p)
     
+    panels =[
+        FieldPanel("url"),
+        FieldPanel("license_p"),
+        FieldPanel("license_type"),
+        AutocompletePanel("language"),
+    ]
+
     @classmethod
     def get_or_create(cls, url, license_p, license_type, language, creator):
         try:

--- a/doi/models.py
+++ b/doi/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from core.choices import LANGUAGE
 from core.forms import CoreAdminModelForm
@@ -19,9 +20,10 @@ class DOI(CommonControlField):
         blank=True,
     )
     autocomplete_search_field = "value"
+    
     panels = [
         FieldPanel("value"),
-        FieldPanel("language"),
+        AutocompletePanel("language"),
     ]
 
     class Meta:
@@ -79,7 +81,7 @@ class DOIRegistration(CommonControlField):
     )
 
     panels = [
-        FieldPanel("doi"),
+        AutocompletePanel("doi"),
         FieldPanel("submission_date"),
         FieldPanel("status"),
     ]

--- a/institution/models.py
+++ b/institution/models.py
@@ -53,7 +53,7 @@ class Institution(CommonControlField, ClusterableModel):
         FieldPanel("name"),
         FieldPanel("acronym"),
         FieldPanel("institution_type"),
-        FieldPanel("location"),
+        AutocompletePanel("location"),
         FieldPanel("level_1"),
         FieldPanel("level_2"),
         FieldPanel("level_3"),
@@ -159,7 +159,7 @@ class InstitutionHistory(models.Model):
     final_date = models.DateField(_("Final Date"), null=True, blank=True)
 
     panels = [
-        FieldPanel("institution", heading=_("Institution")),
+        AutocompletePanel("institution", heading=_("Institution")),
         FieldPanel("initial_date"),
         FieldPanel("final_date"),
     ]

--- a/issue/models.py
+++ b/issue/models.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 from wagtail.fields import RichTextField
 from wagtail.models import Orderable
 
@@ -46,19 +47,18 @@ class Issue(CommonControlField, ClusterableModel):
     month = models.CharField(_("Issue month"), max_length=20, null=True, blank=True)
     supplement = models.CharField(_("Supplement"), max_length=20, null=True, blank=True)
 
-    #FIXME
-    #Melhorar a definicao do campo autocomplete
-    autocomplete_search_field = "number"
+
+    autocomplete_search_field = "journal__title"
 
     def autocomplete_label(self):
-        return f"{self.number}, {self.volume}"
+        return f"{self.journal} {self.volume}, {self.number} {self.supplement}"
 
     panels_issue = [
-        FieldPanel("journal"),
+        AutocompletePanel("journal"),
         FieldPanel("volume"),
         FieldPanel("supplement"),
         FieldPanel("number"),
-        FieldPanel("city"),
+        AutocompletePanel("city"),
         FieldPanel("year"),
         FieldPanel("season"),
         FieldPanel("month"),
@@ -73,11 +73,11 @@ class Issue(CommonControlField, ClusterableModel):
     ]
 
     panels_summary = [
-        FieldPanel("sections"),
+        AutocompletePanel("sections"),
     ]
 
     panels_license = [
-        FieldPanel("license"),
+        AutocompletePanel("license"),
     ]
 
     edit_handler = TabbedInterface(
@@ -222,6 +222,11 @@ class IssueTitle(Orderable, CommonControlField):
     language = models.ForeignKey(
         Language, on_delete=models.CASCADE, blank=True, null=True
     )
+
+    panels = [
+        FieldPanel("title"),
+        AutocompletePanel("language")
+    ]
 
     def __str__(self):
         return self.title

--- a/journal/models.py
+++ b/journal/models.py
@@ -231,7 +231,7 @@ class Journal(CommonControlField, ClusterableModel, SocialNetwork):
         AutocompletePanel("official"),
         FieldPanel("title"),
         FieldPanel("short_title"),
-        FieldPanel("collection"),
+        AutocompletePanel("collection"),
     ]
 
     panels_mission = [
@@ -645,6 +645,11 @@ class SciELOJournal(CommonControlField, ClusterableModel, SocialNetwork):
     )
     # TODO adicionar eventos de entrada e saída de coleção / refatorar journal_and_collection
 
+    autocomplete_search_field = "journal_acron"
+
+    def autocomplete_label(self):
+        return str(self)
+
     class Meta:
         verbose_name = _("SciELO Journal")
         verbose_name_plural = _("SciELO Journals")
@@ -665,7 +670,7 @@ class SciELOJournal(CommonControlField, ClusterableModel, SocialNetwork):
         AutocompletePanel("journal"),
         FieldPanel("journal_acron"),
         FieldPanel("issn_scielo"),
-        FieldPanel("collection"),
+        AutocompletePanel("collection"),
     ]
 
     @classmethod

--- a/journal_and_collection/models.py
+++ b/journal_and_collection/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext as _
 from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from collection.models import Collection
 from core.forms import CoreAdminModelForm
@@ -27,8 +28,13 @@ class Event(CommonControlField):
         blank=True,
     )
 
+    autocomplete_search_filter = "main_name"
+
+    def autocomplete_label(self):
+        return str(self)
+
     panels = [
-        FieldPanel("collection"),
+        AutocompletePanel("collection"),
         FieldPanel("occurrence_date"),
         FieldPanel("occurrence_type"),
     ]
@@ -86,8 +92,8 @@ class JournalAndCollection(CommonControlField):
     )
 
     panels = [
-        FieldPanel("journal"),
-        FieldPanel("events_collection"),
+        AutocompletePanel("journal"),
+        AutocompletePanel("events_collection"),
     ]
 
     class Meta:

--- a/journal_and_collection/models.py
+++ b/journal_and_collection/models.py
@@ -28,7 +28,7 @@ class Event(CommonControlField):
         blank=True,
     )
 
-    autocomplete_search_filter = "main_name"
+    autocomplete_search_field = "collection__main_name"
 
     def autocomplete_label(self):
         return str(self)

--- a/location/models.py
+++ b/location/models.py
@@ -245,7 +245,7 @@ class Location(CommonControlField):
         blank=True,
     )
 
-    autocomplete_search_field = "country"
+    autocomplete_search_field = "country__name"
 
     def autocomplete_label(self):
         return str(self)

--- a/location/models.py
+++ b/location/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext as _
+from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField
@@ -14,6 +16,15 @@ class City(CommonControlField):
     """
 
     name = models.TextField(_("Name of the city"), unique=True)
+
+    autocomplete_search_field = "name"
+
+    def autocomplete_label(self):
+        return str(self)
+    
+    panels = [
+        FieldPanel("name")
+    ]
 
     class Meta:
         verbose_name = _("City")
@@ -45,6 +56,15 @@ class Region(CommonControlField):
     acronym = models.CharField(
         _("Region Acronym"), max_length=10, null=True, blank=True
     )
+
+    autocomplete_search_field = "name"
+
+    def autocomplete_label(self):
+        return str(self)
+
+    panels = [
+        FieldPanel("name")
+    ]
 
     class Meta:
         verbose_name = _("Region")
@@ -94,6 +114,17 @@ class State(CommonControlField):
     name = models.TextField(_("State name"))
     acronym = models.CharField(_("State Acronym"), max_length=2, null=True, blank=True)
     region = models.ForeignKey(Region, on_delete=models.SET_NULL, null=True, blank=True)
+
+    autocomplete_search_field = "name"
+
+    def autocomplete_label(self):
+        return str(self)
+
+    panels = [
+        FieldPanel("name"),
+        FieldPanel("acronym"),
+        AutocompletePanel("region")
+    ]
 
     class Meta:
         verbose_name = _("State")
@@ -145,6 +176,16 @@ class Country(CommonControlField):
         _("Country Acronym"), blank=True, null=True, max_length=255
     )
 
+    autocomplete_search_field = "name"
+
+    def autocomplete_label(self):
+        return str(self)
+    
+    panels = [
+        FieldPanel("name"),
+        FieldPanel("acronym"),
+    ]
+    
     class Meta:
         verbose_name = _("Country")
         verbose_name_plural = _("Countries")
@@ -203,6 +244,18 @@ class Location(CommonControlField):
         null=True,
         blank=True,
     )
+
+    autocomplete_search_field = "country"
+
+    def autocomplete_label(self):
+        return str(self)
+
+    panels = [
+        AutocompletePanel("region"),
+        AutocompletePanel("city"),
+        AutocompletePanel("state"),
+        AutocompletePanel("country"),
+    ]
 
     class Meta:
         verbose_name = _("Location")

--- a/location/scripts/bulk_cities.py
+++ b/location/scripts/bulk_cities.py
@@ -29,4 +29,4 @@ def run(*args):
 
             creator = User.objects.get(id=user_id)
 
-            models.City(name=name, creator=creator).save()
+            models.City.get_or_create(name=name, user=creator)

--- a/location/scripts/bulk_states.py
+++ b/location/scripts/bulk_states.py
@@ -18,18 +18,18 @@ def run(*args):
 
     # Delete all cities
     models.State.objects.all().delete()
+    # User
+    if args:
+        user_id = args[0]
+
+    creator = User.objects.get(id=user_id)
 
     with open(
         os.path.dirname(os.path.realpath(__file__)) + "/../fixtures/states.csv", "r"
     ) as fp:
         for line in fp.readlines():
             name, acron, region = line.strip().split(SEPARATOR)
-
-            # User
-            if args:
-                user_id = args[0]
-
-            creator = User.objects.get(id=user_id)
+            region = models.Region.get_or_create(name=region, user=creator)
 
             models.State(
                 name=name, acronym=acron, region=region, creator=creator

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import json
 from datetime import datetime
 from http import HTTPStatus
 from shutil import copyfile

--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -11,6 +11,7 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.utils.translation import gettext as _
 from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 from packtools.sps.pid_provider import v3_gen, xml_sps_adapter
 
 from core.forms import CoreAdminModelForm
@@ -173,7 +174,7 @@ class PidRequest(CommonControlField):
         FieldPanel("origin_date"),
         FieldPanel("result_type"),
         FieldPanel("result_msg"),
-        FieldPanel("xml_version"),
+        AutocompletePanel("xml_version"),
         FieldPanel("detail"),
     ]
 
@@ -188,6 +189,14 @@ class PidChange(CommonControlField):
     version = models.ForeignKey(
         XMLVersion, null=True, blank=True, on_delete=models.SET_NULL
     )
+
+    panels = [
+        FieldPanel("pkg_name"),
+        FieldPanel("pid_type"),
+        FieldPanel("pid_in_xml"),
+        FieldPanel("pid_assigned"),
+        AutocompletePanel("version")
+    ]
 
     class Meta:
         indexes = [
@@ -268,8 +277,8 @@ class PidProviderXML(CommonControlField):
     base_form_class = CoreAdminModelForm
 
     panels = [
-        FieldPanel("journal"),
-        FieldPanel("issue"),
+        AutocompletePanel("journal"),
+        AutocompletePanel("issue"),
         FieldPanel("pkg_name"),
         FieldPanel("v3"),
         FieldPanel("v2"),
@@ -286,7 +295,7 @@ class PidProviderXML(CommonControlField):
         FieldPanel("z_collab"),
         FieldPanel("z_links"),
         FieldPanel("z_partial_body"),
-        FieldPanel("current_version"),
+        AutocompletePanel("current_version"),
     ]
 
     class Meta:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -53,7 +53,7 @@ django_celery_results==2.5.1
 # Wagtail-Autocomplete
 # https://github.com/wagtail/wagtail-autocomplete
 # ------------------------------------------------------------------------------
-wagtail-autocomplete==0.9.0
+wagtail-autocomplete==0.10.0
 
 
 # Minio

--- a/researcher/models.py
+++ b/researcher/models.py
@@ -38,10 +38,21 @@ class Researcher(ClusterableModel, CommonControlField):
         blank=True,
     )
 
+    autocomplete_search_field = "given_names"
+
     def autocomplete_label(self):
         return str(self)
 
-    autocomplete_search_field = "given_names"
+    panels = [
+        FieldPanel("given_names"),
+        FieldPanel("last_name"),
+        FieldPanel("declared_name"),
+        FieldPanel("suffix"),
+        FieldPanel("orcid"),
+        FieldPanel("lattes"),
+        AutocompletePanel("gender"),
+        FieldPanel("gender_identification_status"),
+    ]
 
     @property
     def get_full_name(self):

--- a/researcher/models.py
+++ b/researcher/models.py
@@ -1,3 +1,5 @@
+import os
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey

--- a/vocabulary/models.py
+++ b/vocabulary/models.py
@@ -12,6 +12,11 @@ class Vocabulary(CommonControlField):
         _("Vocabulary acronym"), max_length=10, null=True, blank=True
     )
 
+    autocomplete_search_field = "name"
+
+    def autocomplete_label(self):
+        return str(self)
+
     def __unicode__(self):
         return "%s - %s" % (self.name, self.acronym) or ""
 

--- a/vocabulary/models.py
+++ b/vocabulary/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils.translation import gettext as _
 from wagtail.admin.panels import FieldPanel
-
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField, TextWithLang
 
@@ -106,7 +106,7 @@ class Keyword(CommonControlField, TextWithLang):
     panels = [
         FieldPanel("text"),
         FieldPanel("language"),
-        FieldPanel("vocabulary"),
+        AutocompletePanel("vocabulary"),
     ]
 
     @property

--- a/xmlsps/models.py
+++ b/xmlsps/models.py
@@ -9,6 +9,7 @@ from django.db.utils import IntegrityError
 from lxml import etree
 from packtools.sps.pid_provider.xml_sps_lib import XMLWithPre
 from wagtail.admin.panels import FieldPanel
+from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from core.forms import CoreAdminModelForm
 from core.models import CommonControlField
@@ -59,6 +60,11 @@ class XMLVersion(CommonControlField):
     file = models.FileField(upload_to=xml_directory_path, null=True, blank=True)
     finger_print = models.CharField(max_length=64, null=True, blank=True)
 
+    autocomplete_search_field = "pid_v3"
+
+    def autocomplete_label(self):
+        return self.pid_v3
+
     class Meta:
         indexes = [
             models.Index(fields=["finger_print"]),
@@ -70,7 +76,6 @@ class XMLVersion(CommonControlField):
             dict(
                 pid_v3=self.pid_v3,
                 created=self.created.isoformat(),
-                xml=self.xml_with_pre.tostring(),
             )
         )
 
@@ -162,6 +167,11 @@ class XMLJournal(models.Model):
     )
     issn_print = models.CharField(_("issn_ppub"), max_length=9, null=True, blank=True)
 
+    autocomplete_search_field = "issn_electronic"
+
+    def autocomplete_label(self):
+        return f"{self.issn_electronic} {self.issn_print}"
+
     class Meta:
         indexes = [
             models.Index(fields=["issn_electronic"]),
@@ -226,6 +236,19 @@ class XMLIssue(models.Model):
     volume = models.CharField(_("volume"), max_length=10, null=True, blank=True)
     number = models.CharField(_("number"), max_length=10, null=True, blank=True)
     suppl = models.CharField(_("suppl"), max_length=10, null=True, blank=True)
+
+    autocomplete_search_field = "pub_year"
+
+    def autocomplete_label(self):
+        return str(self)
+
+    panels = [
+        AutocompletePanel("journal"),
+        FieldPanel("pub_year"),
+        FieldPanel("volume"),
+        FieldPanel("number"),
+        FieldPanel("suppl"),
+    ]
 
     class Meta:
         unique_together = [
@@ -329,9 +352,9 @@ class XMLSPS(CommonControlField):
         FieldPanel("pid_v3"),
         FieldPanel("pid_v2"),
         FieldPanel("aop_pid"),
-        FieldPanel("xml_journal"),
-        FieldPanel("xml_issue"),
-        FieldPanel("xml_version"),
+        AutocompletePanel("xml_journal"),
+        AutocompletePanel("xml_issue"),
+        AutocompletePanel("xml_version"),
     ]
 
     class Meta:


### PR DESCRIPTION
#### O que esse PR faz?
Adicionar suporte para  AutoCompletePanel em todos os campos Many-to-Many e ForeignKey

#### Onde a revisão poderia começar?
A partir do commit https://github.com/scieloorg/core/pull/323/commits/a6573ffa048d6830b51f2b1a6e699e19ad58662d

#### Como este poderia ser testado manualmente?

1. make build
2. make up
3. Acessa: [0.0.0.0:8000/admin/](http://0.0.0.0:8000/admin/)

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/core/issues/322

### Referências
https://wagtail-autocomplete.readthedocs.io/en/latest/

