### PR TITLE
Apresenta na área restrita, nas listas de PidRequest, PidProviderXML, PidChange, as datas de atualização ou criação

### DIFF
--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -179,6 +179,10 @@ class PidRequest(CommonControlField):
             detail=detail,
         )
 
+    @property
+    def created_updated(self):
+        return self.updated or self.created
+
     panels = [
         FieldPanel("origin"),
         FieldPanel("origin_date"),
@@ -242,6 +246,10 @@ class PidChange(CommonControlField):
             obj.version = version
             obj.save()
             return obj
+
+    @property
+    def created_updated(self):
+        return self.updated or self.created
 
 
 class PidProviderXML(CommonControlField):
@@ -333,6 +341,10 @@ class PidProviderXML(CommonControlField):
 
     def __str__(self):
         return f"{self.pkg_name} {self.v3}"
+
+    @property
+    def created_updated(self):
+        return self.updated or self.created
 
     @property
     def data(self):

--- a/pid_provider/wagtail_hooks.py
+++ b/pid_provider/wagtail_hooks.py
@@ -31,7 +31,7 @@ class PidRequestAdmin(ModelAdmin):
         "origin",
         "result_type",
         "result_msg",
-        "created",
+        "created_updated",
     )
     list_filter = ("result_type",)
     search_fields = (
@@ -63,6 +63,7 @@ class PidProviderXMLAdmin(ModelAdmin):
         "v2",
         "aop_pid",
         "main_doi",
+        "created_updated",
     )
     list_filter = ("article_pub_year",)
     search_fields = (
@@ -97,6 +98,7 @@ class PidChangeAdmin(ModelAdmin):
         "pid_in_xml",
         "pid_assigned",
         "pid_type",
+        "created_updated",
     )
     list_filter = ("pid_type",)
     search_fields = (


### PR DESCRIPTION
#### O que esse PR faz?
Apresenta na área restrita, nas listas de PidRequest, PidProviderXML, PidChange, as datas de atualização ou criação

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
- Acesse área restrita
- Acesse o menu Pid Provider
- Entre em Pid Request, Pid Provider XML e Pid Change e observe a última coluna é "created_updated"

#### Algum cenário de contexto que queira dar?
Isso economiza espaço se é desejável saber apenas a data mais recente seja de atualização ou de criação

### Screenshots

<img width="141" alt="Captura de Tela 2023-10-30 às 19 58 18" src="https://github.com/scieloorg/core/assets/505143/84bc921f-08b4-46f8-a1df-ad3c6990a294">


#### Quais são tickets relevantes?
n/a

### Referências
n/a

