### PR TITLE
Cambios en presentación de campos ManyToMany

### DIFF
--- a/journal/models.py
+++ b/journal/models.py
@@ -517,17 +517,17 @@ class Journal(CommonControlField, ClusterableModel):
         InlinePanel("mission", label=_("Mission"), classname="collapsed"),
         InlinePanel("history", label=_("Brief History"), classname="collapsed"),
         InlinePanel("focus", label=_("Focus and Scope"), classname="collapsed"),
-        FieldPanel("subject_descriptor"),
+        AutocompletePanel("subject_descriptor"),
         FieldPanel("subject"),
         FieldPanel("wos_db"),
-        FieldPanel("wos_area"),
+        AutocompletePanel("wos_area"),
     ]
 
     panels_formal_information = [
         FieldPanel("frequency"),
         FieldPanel("publishing_model"),
-        FieldPanel("text_language"),
-        FieldPanel("abstract_language"),
+        AutocompletePanel("text_language"),
+        AutocompletePanel("abstract_language"),
         FieldPanel("standard"),
         AutocompletePanel("vocabulary"),
         FieldPanel("alphabet"),
@@ -542,7 +542,7 @@ class Journal(CommonControlField, ClusterableModel):
         FieldPanel("secs_code"),
         FieldPanel("medline_code"),
         FieldPanel("medline_short_title"),
-        FieldPanel("indexed_at"),
+        AutocompletePanel("indexed_at"),
     ]
 
     panels_institutions = [
@@ -1150,8 +1150,16 @@ class JournalParallelTitles(TextWithLang):
 class SubjectDescriptor(CommonControlField):
     value = models.CharField(max_length=255, null=True, blank=True)
 
+    autocomplete_search_field = "value"
+
+    def autocomplete_label(self):
+        return str(self)
+
     def __str__(self):
         return f"{self.value}"
+    
+    class Meta:
+        ordering = ['value']
 
 
 class Subject(CommonControlField):
@@ -1225,8 +1233,16 @@ class WebOfKnowledge(CommonControlField):
 class WebOfKnowledgeSubjectCategory(CommonControlField):
     value = models.CharField(max_length=100, null=True, blank=True)
 
+    autocomplete_search_field = "value"
+
+    def autocomplete_label(self):
+        return str(self)
+
     def __str__(self):
         return f"{self.value}"
+
+    class Meta:
+        ordering = ['value']
 
 
 class Standard(CommonControlField):
@@ -1302,6 +1318,9 @@ class IndexedAt(CommonControlField):
 
     def __str__(self):
         return f"{self.acronym} - {self.name}"
+
+    class Meta:
+        ordering = ['name']
 
     @classmethod
     def get(


### PR DESCRIPTION
#### O que esse PR faz?
Cambiao en la presentacion de los campos adoptando Autocomplete

 Subject Descriptors
 Web of Knowledge Subject Categories
 text languages
 abstract languages
 index at

Además se hace el ordenamiento en Subject Descriptors, Web of Knowledge Subject Categories e index at

#### Onde a revisão poderia começar?
por commit

#### Como este poderia ser testado manualmente?
Revisión de catálogos

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![image](https://github.com/scieloorg/core/assets/58487702/b620f22f-a4c6-4fcd-ac9d-94c9c8677dc5)
![image](https://github.com/scieloorg/core/assets/58487702/7f3c5766-a657-4f3f-9c9e-499188d9716d)
![image](https://github.com/scieloorg/core/assets/58487702/d47feea8-4b5e-4464-8f3e-cefcc2268444)
![image](https://github.com/scieloorg/core/assets/58487702/bad732e1-68f3-49c9-b705-e937abe33f74)


#### Quais são tickets relevantes?
https://github.com/scieloorg/core/issues/393

### Referências
N/A
