### PR TITLE
Atualiza a versão de packtools para 3.2.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,8 @@ minio==7.1.17
 # ------------------------------------------------------------------------------
 lxml==4.9.4 # https://github.com/lxml/lxml
 tornado>=6.3.3 # not directly required, pinned by Snyk to avoid a vulnerability
--e git+https://git@github.com/scieloorg/packtools@3.2.1#egg=packtools
+#-e git+https://git@github.com/scieloorg/packtools@3.2.3#egg=packtools
+packtools@https://github.com/scieloorg/packtools/archive/refs/tags/3.2.3.zip
 
 # Sickle
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### O que esse PR faz?
Atualiza a versão de packtools para 3.2.3
Corrige o valor do atributo `XMLWithPre.article_publication_date` usado pelo pid provider, obtido de `packtools.sps.models.dates.ArticleDates`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
```console
python -m pip install packtools@https://github.com/scieloorg/packtools/archive/refs/tags/3.2.3.zip
```

Problema ocorria ao atribuir pid para artigo que contém data incompleta e pub-type='epub' (versão anterior a SPS 1.8):
```xml
<pub-date pub-type="epub"><year>2020</year></pub-date>
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

