### PR TITLE
Adiciona em PidProviderXML.public_items a condição de registros que possuem `current_version__pid_v3__isnull=False`

### DIFF
--- a/pid_provider/models.py
+++ b/pid_provider/models.py
@@ -413,6 +413,7 @@ class PidProviderXML(CommonControlField):
         return cls.objects.filter(
             Q(website_publication_date__lte=now)
             & (Q(created__gte=from_date) | Q(updated__gte=from_date)),
+            current_version__pid_v3__isnull=False,
         ).iterator()
 
     @property


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona em PidProviderXML.public_items a condição de registros que possuem `current_version__pid_v3__isnull=False` para evitar que se tente gerar Article a partir XML que estejam incompletos 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Processando a tarefa load_articles

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

