### PR TITLE
[Melhoria UX] Coloca journal como primeira coluna de SciELOJournal e acrescenta as colunas status e filtro status e collection

### DIFF
--- a/journal/wagtail_hooks.py
+++ b/journal/wagtail_hooks.py
@@ -103,15 +103,18 @@ class SciELOJournalAdmin(ModelAdmin):
     exclude_from_explorer = False
 
     list_display = (
-        "collection",
+        "journal",
         "issn_scielo",
         "journal_acron",
-        "journal",
+        "collection",
+        "status",
         "created",
         "updated",
     )
+    list_filter = ("status", "collection", )
     search_fields = (
         "journal_acron",
+        "journal__title",
         "issn_scielo",
     )
 


### PR DESCRIPTION
#### O que esse PR faz?
Coloca journal como primeira coluna de SciELOJournal e acrescenta as colunas status e filtro status e collection

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Acessando a página SciELO Journals

#### Algum cenário de contexto que queira dar?
A ordenação por título de journal não funciona, pois journal é um FK.
Fica pendente dar solução para a ordenação por título

### Screenshots
<img width="1247" alt="Captura de Tela 2024-01-04 às 18 45 11" src="https://github.com/scieloorg/core/assets/505143/630ed836-5a8a-4f3f-a769-7154c8f4a40b">


#### Quais são tickets relevantes?
Relacionado com #530 

### Referências
n/a
