### PR TITLE
[WIP] Adiciona verificação de usuário nulo ao parâmetro 'user' em 'provide_pid_for_xml_uri'

### DIFF
--- a/pid_provider/base_pid_provider.py
+++ b/pid_provider/base_pid_provider.py
@@ -117,7 +117,7 @@ class BasePidProvider:
                     "operation": "PidProvider.provide_pid_for_xml_uri",
                     "input": dict(
                         xml_uri=xml_uri,
-                        user=user.username,
+                        user=user.username if user else "None",
                         name=name,
                         origin_date=origin_date,
                         force_update=force_update,


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona verificação de usuário nulo ao parâmetro 'user' em 'provide_pid_for_xml_uri'

#### Onde a revisão poderia começar?
pelo commit https://github.com/scieloorg/core/commit/f6e55804bcff8fee9ee5fc2087676723de9a3484

#### Como este poderia ser testado manualmente?
python manage.py runscript provide_pid_for_opac_xmls --script-args {username} 1900-01-01 2023-12-21 100 1000

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

