### PR TITLE
Corrige a função 'create_or_update_location' para preencher os dados corretamente no modelo Location.

### DIFF
--- a/journal/sources/am_to_core.py
+++ b/journal/sources/am_to_core.py
@@ -753,7 +753,7 @@ def create_or_update_location(
         [{'_': 'Rua Felizardo, 750 Jardim Botânico'}, {'_': 'CEP: 90690-200'}, {'_': 'RS - Porto Alegre'}, {'_': '(51) 3308 5814'}]
     """
 
-    country = standardize_location(extract_value(publisher_city), Country, user=user)
+    country = standardize_location(extract_value(publisher_country), Country, user=user)
     city = standardize_location(extract_value(publisher_city), City, user=user)
     state = standardize_location(extract_value(publisher_state), State, user=user)
 

--- a/location/models.py
+++ b/location/models.py
@@ -534,10 +534,10 @@ class Location(CommonControlField):
         unique_together = [("country", "state", "city")]
 
     def __unicode__(self):
-        return f"{self.country} | {self.state} | {self.city}"
+        return f"{self.city}, {self.state}, {self.country}"
 
     def __str__(self):
-        return f"{self.country} | {self.state} | {self.city}"
+        return f"{self.city}, {self.state}, {self.country}"
     
     @property
     def formatted_location(self):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a função 'create_or_update_location' para preencher os dados corretamente no modelo Location.

#### Onde a revisão poderia começar?
Pelos commits

#### Como este poderia ser testado manualmente?

1. make django_bash
2. python manage.py runscript load_journal_from_am_journal --script-args {username}

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![image](https://github.com/scieloorg/core/assets/82840278/461d241f-8969-4cd3-b093-1da3de7a0a5c)


#### Quais são tickets relevantes?
https://github.com/scieloorg/core/issues/658

### Referências
N/A

