### PR TITLE
Fix: function xmlsps.get_or_create_issues

### DIFF
--- a/article/sources/xmlsps.py
+++ b/article/sources/xmlsps.py
@@ -585,16 +585,22 @@ def get_or_create_article_type(xmltree, user):
 
 def get_or_create_issues(xmltree, user, item):
     issue_data = ArticleMetaIssue(xmltree=xmltree).data
-    collection_date = HistoryDates(xmltree=xmltree).collection_date
+    history_dates = HistoryDates(xmltree=xmltree)
+    collection_date = history_dates.collection_date or {}
+
+    season = collection_date.get("season")
+    year = collection_date.get("year")
+    month = collection_date.get("month")
+    suppl = collection_date.get("suppl")
     try:
         obj = Issue.get_or_create(
             journal=get_journal(xmltree=xmltree),
             number=issue_data.get("number"),
             volume=issue_data.get("volume"),
-            season=collection_date.get("season"),
-            year=collection_date.get("year"),
-            month=collection_date.get("month"),
-            supplement=collection_date.get("suppl"),
+            season=season,
+            year=year,
+            month=month,
+            supplement=suppl,
             user=user,
         )
         return obj


### PR DESCRIPTION
#### O que esse PR faz?
Evita erro de NoneType object has no attribute 'get' em collection_date

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?

1. Baixar os arquivos:
https://core.scielo.org/media/pid_provider/1678/4170/abc/abc/20210792/J9zrJ5mDWLY5K44hcyXm5Sz.xml
https://core.scielo.org/media/pid_provider/2395/8464/secu/00/104/e1369/N8fpQycc5f79GKZGgkx5NRx.xml
2. Executar a função: ```python python manage.py runscript load_article --script-args 1```

#### Algum cenário de contexto que queira dar?
Importante notar que alguns xmls não vão possuir todos os dados relacionado ao issue. Em ```J9zrJ5mDWLY5K44hcyXm5Sz``` não há nenhum dado relacionado a data de publicação e issue.

### Screenshots
N/A

#### Quais são tickets relevantes?
#861 

### Referências
N/A

