### PR TITLE
Corrige a coleta de dados de issue do articlemeta

### DIFF
--- a/core/utils/rename_dictionary_keys.py
+++ b/core/utils/rename_dictionary_keys.py
@@ -29,16 +29,14 @@ def rename_issue_dictionary_keys(list_dictionary, corresp):
     Returns:
         dict: Um novo dicionário com as chaves atualizadas de acordo com o dicionário de correspondência.
     """
-    logging.info(corresp)
-    logging.info(list_dictionary)
     
     d = {}
     for dictionary in list_dictionary:
         for key in dictionary:
             try:
-                k = corresp.get(key) or key
+                k = corresp.get(key, key)
                 d[k] = dictionary[key]
             except Exception as e:
-                logging.exception(e)
-                logging.info(key)
+                logging.exception(f"Erro ao renomear a chave '{key}': {e}")
+                logging.info(f"Chave problemática: '{key}' com valor '{dictionary[key]}'.")
     return d

--- a/core/utils/rename_dictionary_keys.py
+++ b/core/utils/rename_dictionary_keys.py
@@ -1,3 +1,6 @@
+import logging
+
+
 def rename_dictionary_keys(list_dictionary, corresp):
     """
     Renomeia as chaves de um dicionário com base em um dicionário de correspondência.
@@ -14,3 +17,28 @@ def rename_dictionary_keys(list_dictionary, corresp):
         for dictionary in list_dictionary
         for key in dictionary
     }
+
+
+def rename_issue_dictionary_keys(list_dictionary, corresp):
+    """
+    Renomeia as chaves de um dicionário com base em um dicionário de correspondência.
+
+    Args:
+        list_dictionary (list): Lista de dicionário.
+
+    Returns:
+        dict: Um novo dicionário com as chaves atualizadas de acordo com o dicionário de correspondência.
+    """
+    logging.info(corresp)
+    logging.info(list_dictionary)
+    
+    d = {}
+    for dictionary in list_dictionary:
+        for key in dictionary:
+            try:
+                k = corresp.get(key) or key
+                d[k] = dictionary[key]
+            except Exception as e:
+                logging.exception(e)
+                logging.info(key)
+    return d

--- a/issue/sources/article_meta.py
+++ b/issue/sources/article_meta.py
@@ -15,15 +15,9 @@ def process_issue_article_meta(collection, limit, user):
             code = issue["code"]
             url_issue = f"https://articlemeta.scielo.org/api/v1/issue/?code={code}"
             data_issue = utils.fetch_data(url_issue, json=True, timeout=30, verify=True)
-
-            try:
-                issue_dict = rename_issue_dictionary_keys(
-                    [data_issue["issue"]], correspondencia_issue
-                )
-            except Exception as e:
-                logging.exception(e)
-                logging.info(data_issue["issue"], correspondencia_issue)
-                continue
+            issue_dict = rename_issue_dictionary_keys(
+                [data_issue["issue"]], correspondencia_issue
+            )
             try:
                 get_or_create_issue(
                     issn_scielo=issue_dict.get("scielo_issn"),
@@ -36,7 +30,7 @@ def process_issue_article_meta(collection, limit, user):
                     user=user,
                 )
             except Exception as exc:
-                logging.exception(f"{code} {exc}")
+                logging.exception(f"Error ao criar isssue com code: {code}. Exception: {exc}")
         offset += 100
         data = request_issue_article_meta(
             collection=collection, limit=limit, offset=offset

--- a/issue/sources/article_meta.py
+++ b/issue/sources/article_meta.py
@@ -1,5 +1,7 @@
+import logging
+
 from core.utils import utils
-from core.utils.rename_dictionary_keys import rename_dictionary_keys
+from core.utils.rename_dictionary_keys import rename_issue_dictionary_keys
 from issue.utils.correspondencia import correspondencia_issue
 from issue.utils.issue_utils import get_or_create_issue
 
@@ -13,19 +15,28 @@ def process_issue_article_meta(collection, limit, user):
             code = issue["code"]
             url_issue = f"https://articlemeta.scielo.org/api/v1/issue/?code={code}"
             data_issue = utils.fetch_data(url_issue, json=True, timeout=30, verify=True)
-            issue_dict = rename_dictionary_keys(
-                data_issue["issue"], correspondencia_issue
-            )
-            get_or_create_issue(
-                issn_scielo=issue_dict.get("scielo_issn"),
-                volume=issue_dict.get("volume"),
-                number=issue_dict.get("number"),
-                supplement_volume=issue_dict.get("suplement_volume"),
-                supplement_number=issue_dict.get("suplement_number"),
-                data_iso=issue_dict.get("date_iso"),
-                sections_data=issue_dict.get("sections_data"),
-                user=user,
-            )
+
+            try:
+                issue_dict = rename_issue_dictionary_keys(
+                    [data_issue["issue"]], correspondencia_issue
+                )
+            except Exception as e:
+                logging.exception(e)
+                logging.info(data_issue["issue"], correspondencia_issue)
+                continue
+            try:
+                get_or_create_issue(
+                    issn_scielo=issue_dict.get("scielo_issn"),
+                    volume=issue_dict.get("volume"),
+                    number=issue_dict.get("number"),
+                    supplement_volume=issue_dict.get("suplement_volume"),
+                    supplement_number=issue_dict.get("suplement_number"),
+                    data_iso=issue_dict.get("date_iso"),
+                    sections_data=issue_dict.get("sections_data"),
+                    user=user,
+                )
+            except Exception as exc:
+                logging.exception(f"{code} {exc}")
         offset += 100
         data = request_issue_article_meta(
             collection=collection, limit=limit, offset=offset

--- a/issue/utils/issue_utils.py
+++ b/issue/utils/issue_utils.py
@@ -38,7 +38,7 @@ def get_scielo_journal(issn_scielo):
         issn_scielo = extract_value(issn_scielo)
         return SciELOJournal.objects.get(issn_scielo=issn_scielo)
     except SciELOJournal.DoesNotExist:
-        logging.exception(f"SciELOJournal {issn_scielo}")
+        logging.exception(f"Nenhum SciELOJournal encontrado com ISSN: {issn_scielo}")
         return None
     except SciELOJournal.MultipleObjectsReturned:
         return SciELOJournal.objects.filter(issn_scielo=issn_scielo).first()

--- a/issue/utils/issue_utils.py
+++ b/issue/utils/issue_utils.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ObjectDoesNotExist
+import logging
 
 from core.models import Language
 from journal.models import SciELOJournal
@@ -37,8 +37,11 @@ def get_scielo_journal(issn_scielo):
     try:
         issn_scielo = extract_value(issn_scielo)
         return SciELOJournal.objects.get(issn_scielo=issn_scielo)
-    except ObjectDoesNotExist:
+    except SciELOJournal.DoesNotExist:
+        logging.exception(f"SciELOJournal {issn_scielo}")
         return None
+    except SciELOJournal.MultipleObjectsReturned:
+        return SciELOJournal.objects.filter(issn_scielo=issn_scielo).first()
 
 
 def extract_date(date):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige a coleta de dados de issue do articlemeta.
O principal problema é que em no lugar de 
```python
            issue_dict = rename_dictionary_keys(
                data_issue["issue"], correspondencia_issue
            )
```
no lugar de

```python
data_issue["issue"]
```

deveria ser

```python
[data_issue["issue"]]
```
Mas estava difícil de identificar o problema. Foi necessário deixar a função `rename_dictionary_keys` mais legível e adicionar  logging na função.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando a tarefa de coleta de dados de issue do articlemeta

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
