### PR TITLE
Adiciona as variáveis de ambiente relacionadas com SESSION

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -56,6 +56,20 @@ SECURE_CONTENT_TYPE_NOSNIFF = env.bool(
     "DJANGO_SECURE_CONTENT_TYPE_NOSNIFF", default=True
 )
 
+# Duração máxima da sessão em segundos. Padrão: 30 minutos (1800s).
+# Sobrescreva com a variável de ambiente DJANGO_SESSION_COOKIE_AGE. Ex: export DJANGO_SESSION_COOKIE_AGE=3600
+SESSION_COOKIE_AGE = int(os.getenv('DJANGO_SESSION_COOKIE_AGE', 30 * 60))
+
+# Se o cookie da sessão expira ao fechar o navegador. Padrão: True (conforme 'true' no getenv).
+# Sobrescreva com DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE=False para persistir.
+# Ex: export DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE=False
+SESSION_EXPIRE_AT_BROWSER_CLOSE = os.getenv('DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE', 'True').lower() == 'true'
+
+# Salva a sessão a cada requisição. Essencial para timeout por inatividade. Padrão: True.
+# Sobrescreva com DJANGO_SESSION_SAVE_EVERY_REQUEST=False para desativar.
+# Ex: export DJANGO_SESSION_SAVE_EVERY_REQUEST=False
+SESSION_SAVE_EVERY_REQUEST = os.getenv('DJANGO_SESSION_SAVE_EVERY_REQUEST', 'True').lower() == 'true'
+
 # STATIC
 # ------------------------
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"


### PR DESCRIPTION

### O que esse PR faz?

Este PR introduz configurações para o **tempo de vida e comportamento das sessões do Django** no ambiente de produção. Ele permite que o administrador do sistema configure a duração máxima de uma sessão, se a sessão deve expirar ao fechar o navegador, e se a sessão deve ser salva a cada requisição, tudo através de variáveis de ambiente. O propósito principal é oferecer mais flexibilidade e controle sobre a gestão de sessões, especialmente para implementar políticas de timeout por inatividade de forma eficaz.

-----

### Onde a revisão poderia começar?

A revisão pode começar no arquivo:
`seu_projeto/settings/production.py`

-----

### Como este poderia ser testado manualmente?

1.  **Ajuste das Variáveis de Ambiente:** Antes de iniciar a aplicação, defina as variáveis de ambiente conforme desejar:
      * `export DJANGO_SESSION_COOKIE_AGE=60` (para uma sessão de 60 segundos)
      * `export DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE=False` (para persistir a sessão após fechar o navegador)
      * `export DJANGO_SESSION_SAVE_EVERY_REQUEST=True` (para salvar a sessão a cada requisição)
2.  **Inicie a Aplicação:** Suba a aplicação Django em modo de produção.
3.  **Faça Login:** Autentique-se na aplicação.
4.  **Teste `SESSION_COOKIE_AGE`:**
      * Com `DJANGO_SESSION_COOKIE_AGE` definido para um valor baixo (e.g., 60 segundos), após o período configurado, a sessão deve expirar automaticamente, exigindo um novo login.
5.  **Teste `SESSION_EXPIRE_AT_BROWSER_CLOSE`:**
      * Com `DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE=False`: Faça login, feche o navegador e reabra-o. O usuário deve permanecer logado.
      * Com `DJANGO_SESSION_EXPIRE_AT_BROWSER_CLOSE=True` (padrão): Faça login, feche o navegador e reabra-o. O usuário deve ser deslogado.
6.  **Teste `SESSION_SAVE_EVERY_REQUEST`:**
      * Embora menos visível, garantir que `SESSION_SAVE_EVERY_REQUEST=True` é fundamental para o **timeout por inatividade**. Se esta variável for `True`, qualquer requisição renovará o tempo de vida da sessão, prevenindo o logout automático enquanto o usuário estiver ativo na aplicação. Você pode observar o `session_key` no cookie ou no banco de dados para verificar se ele é atualizado a cada requisição.

-----

### Algum cenário de contexto que queira dar?

Estas configurações são cruciais para sistemas que precisam aderir a **políticas de segurança rígidas**, como o logout automático após um período de inatividade. Ao externalizar esses parâmetros para variáveis de ambiente, facilitamos a gestão e a adaptação do comportamento da sessão sem a necessidade de modificar o código-fonte da aplicação, o que é ideal para ambientes de produção e integração contínua.

-----

### Screenshots

(Não aplicável para esta alteração de configuração de backend, pois não há impacto visual direto na interface do usuário.)

-----

### Quais são tickets relevantes?

  * (Se houver um ticket no seu sistema de gerenciamento de projetos, adicione-o aqui, por exemplo: `#1234 - Implementar controle de sessão por variáveis de ambiente`)

-----

### Referências

  * [[Documentação oficial do Django sobre configurações de sessão](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/settings/%23sessions)](https://www.google.com/search?q=https://docs.djangoproject.com/en/stable/ref/settings/%23sessions)

