### PR TITLE
Fix: Verify silk instaled app urls

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -75,7 +75,6 @@ if settings.DEBUG:
     # This allows the error pages to be debugged during development, just visit
     # these url in browser to see how these error pages look like.
     urlpatterns += [
-        path('silk/', include('silk.urls', namespace='silk')),
         path(
             "400/",
             default_views.bad_request,
@@ -97,3 +96,6 @@ if settings.DEBUG:
         import debug_toolbar
 
         urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+
+    if "silk" in settings.INSTALLED_APPS:
+        urlpatterns += [path('silk/', include('silk.urls', namespace='silk'))]


### PR DESCRIPTION
#### O que esse PR faz?
Verificar a instalação de django-silk antes de incluir nas urls

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
build do projeto

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a

