### PR TITLE
Abordagem configuravel para executar pid provider

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -380,7 +380,7 @@ TASK_QUEUE = env('TASK_QUEUE', default='high')
 # Tempo máximo em segundos que uma tarefa pode levar para ser concluída (timeout "suave").
 # `env.int()` garante que o valor lido seja um inteiro.
 TASK_TIMEOUT = env.int('TASK_TIMEOUT', default=5 * 60)
-
+RUN_ASYNC = env.int('RUN_ASYNC', default=0)
 # Celery Results
 # ------------------------------------------------------------------------------
 # https: // django-celery-results.readthedocs.io/en/latest/getting_started.html

--- a/pid_provider/tasks.py
+++ b/pid_provider/tasks.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import logging
 
 from django.contrib.auth import get_user_model
 
@@ -290,6 +291,7 @@ def task_provide_pid_for_xml_zip(
 ):
     try:
         user = _get_user(self.request, username=username, user_id=user_id)
+        logging.info("Running task_provide_pid_for_xml_zip")
         response = pid_provider.provide_pid_for_xml_zip(
             zip_filename,
             user,
@@ -300,6 +302,7 @@ def task_provide_pid_for_xml_zip(
             registered_in_core=None,
             caller="core",
         )
+        logging.info("fim Running task_provide_pid_for_xml_zip")
         try:
             response = list(response)[0]
         except IndexError:


### PR DESCRIPTION
#### O que esse PR faz?
Este Pull Request introduz a funcionalidade de alternar entre o processamento **assíncrono (via Celery)** e **síncrono** de arquivos ZIP para a provisão de PIDs. Anteriormente, todas as requisições de PID eram processadas de forma assíncrona, o que, embora robusto para grandes volumes, adicionava uma camada de complexidade e latência para operações que poderiam ser concluídas rapidamente.

Com a adição da variável de ambiente `RUN_ASYNC`, é possível configurar a aplicação para processar a tarefa `task_provide_pid_for_xml_zip` de forma síncrona (`RUN_ASYNC=0`) ou assíncrona (`RUN_ASYNC=1`). Isso permite otimizar o fluxo para casos onde a resposta imediata é preferível e a carga de trabalho permite o processamento síncrono, ou manter o comportamento assíncrono para operações mais pesadas e resiliência.

Além disso, adiciona logs para auxiliar na depuração e monitoramento do fluxo de processamento (síncrono/assíncrono) e melhora o tratamento de conexões de banco de dados no modo síncrono.

#### Onde a revisão poderia começar?
A revisão pode começar em `config/settings/base.py` para observar a adição da variável `RUN_ASYNC`. Em seguida, o foco principal deve ser `pid_provider/api/v1/views.py`, especificamente na classe `PidProviderViewSet` e nas novas funções `run_async` e `run_sync`.

#### Como este poderia ser testado manualmente?
1.  **Modo Assíncrono (Comportamento Atual):**
    * Garanta que o Celery e o Redis estejam configurados e rodando.
    * Defina a variável de ambiente `RUN_ASYNC=1`.
    * Envie um arquivo ZIP com XMLs para a API de provisão de PID (ex: `POST /api/v1/pids/`).
    * Verifique se a resposta inicial é `HTTP 202 Accepted` com `record_status: processing` e se a tarefa Celery é executada em segundo plano.

2.  **Modo Síncrono (Novo Comportamento):**
    * Defina a variável de ambiente `RUN_ASYNC=0`.
    * Envie um arquivo ZIP com XMLs para a API de provisão de PID (ex: `POST /api/v1/pids/`).
    * Verifique se a resposta é imediata (`HTTP 200 OK` ou `HTTP 201 Created`, dependendo do `record_status` final) e se o processamento acontece dentro da mesma requisição.
    * Verifique os logs da aplicação para confirmar que a execução "Sync" foi registrada.

3.  **Testar com arquivos pequenos e grandes:**
    * Observe o comportamento da API com arquivos de diferentes tamanhos em ambos os modos para entender o impacto na latência e no uso de recursos.

#### Algum cenário de contexto que queira dar?
Atualmente, todas as requisições de provisão de PID para arquivos ZIP são enviadas para o Celery, mesmo quando o volume de XMLs é pequeno ou a resposta em tempo real é mais crítica para a experiência do usuário. Isso introduz uma latência inerente devido à comunicação com a fila de tarefas e o worker do Celery. Para cenários onde a carga de trabalho é leve e o throughput não é a preocupação principal, mas sim a resposta imediata, o processamento síncrono pode ser mais eficiente e direto.

Esta mudança visa proporcionar flexibilidade, permitindo que a equipe de operações e desenvolvimento escolha o modo de processamento ideal (`síncrono` ou `assíncrono`) com base nas características de uso e na performance desejada em diferentes ambientes (desenvolvimento, staging, produção com diferentes cargas).

### Screenshots
N/A (As mudanças são focadas em lógica de backend e performance, sem impacto direto na interface do usuário).

#### Quais são tickets relevantes?
n/a

### Referências
N/A