### PR TITLE
Adiciona dados de licença e location na API de Journal

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -539,6 +539,18 @@ class Location(CommonControlField):
         return f"{_('Country')}: {self.country}, {_('State')}: {self.state}, {_('City')}: {self.city}"
     
     @property
+    def data(self):
+        d = {
+            "city_name": self.city.name if self.city else None,
+            "state_name": self.state.name if self.state else None,
+            "state_acronym": self.state.acronym if self.state else None,
+            "country_name": self.country.name if self.country else None,
+            "country_acronym": self.country.acronym if self.country else None,
+            "country_acron3": self.country.acron3 if self.country else None,
+        }
+        return d
+
+    @property
     def formatted_location(self):
         parts = []
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona dados de licensa e location na API de Journal

#### Onde a revisão poderia começar?
pelos commits

#### Como este poderia ser testado manualmente?
acessar: http://0.0.0.0:8009/api/v1/journal/?issn_electronic=2317-6326

#### Algum cenário de contexto que queira dar?
format location:
```json
"location": {
    "city_name": "São Paulo",
    "state_name": null,
    "state_acronym": "SP",
    "country_name": "Brasil",
    "country_acronym": "BR",
    "country_acron3": "BRA"
},
```
format journal_use_license:
```json
"journal_use_license": "BY",
```
### Screenshots
N/A

#### Quais são tickets relevantes?
#1099 

### Referências
N/A

