### PR TITLE
refactor: usa constantes de configuração para nomes de grupos

### DIFF
--- a/core/users/models.py
+++ b/core/users/models.py
@@ -3,6 +3,8 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from config.settings.base import COLLECTION_TEAM, JOURNAL_TEAM
+
 
 class User(AbstractUser):
     """
@@ -74,9 +76,9 @@ class User(AbstractUser):
     @property
     def has_collection_permission(self):
         """Verifica se o usuário tem permissões de collection."""
-        return self.groups.filter(name='COLLECTION_TEAM').exists()
+        return self.groups.filter(name=COLLECTION_TEAM).exists()
     
     @property
     def has_journal_permission(self):
         """Verifica se o usuário tem permissões de journal."""
-        return self.groups.filter(name='JOURNAL_TEAM').exists()
+        return self.groups.filter(name=JOURNAL_TEAM).exists()


### PR DESCRIPTION
## Refatoração: Uso de constantes para grupos de permissão

### O que esse PR faz?
Este PR refatora o modelo `User` para utilizar constantes de configuração ao invés de strings hardcoded para verificação de grupos de permissão. Isso resolve o problema de manutenibilidade onde os nomes dos grupos estavam duplicados no código, criando pontos de falha caso seja necessário alterar os nomes dos grupos no futuro.

**Mudanças realizadas:**
- Importa `COLLECTION_TEAM` e `JOURNAL_TEAM` de `config.settings.base`
- Remove strings hardcoded 'COLLECTION_TEAM' e 'JOURNAL_TEAM'
- Melhora manutenibilidade centralizando configuração de grupos

### Onde a revisão poderia começar?
`core/users/models.py` - linhas 76-83, especificamente os métodos `has_collection_permission` e `has_journal_permission`

### Como este poderia ser testado manualmente?
1. Criar um usuário de teste no admin
2. Adicionar o usuário ao grupo correspondente (COLLECTION_TEAM ou JOURNAL_TEAM)
3. No shell do Django, verificar se as permissões funcionam corretamente:
```python
from core.users.models import User
user = User.objects.get(username='teste')
print(user.has_collection_permission)  # Deve retornar True/False conforme o grupo
print(user.has_journal_permission)     # Deve retornar True/False conforme o grupo
```
4. Verificar que o comportamento permanece idêntico ao anterior

### Algum cenário de contexto que queira dar?
Esta refatoração faz parte de um esforço maior para padronizar e centralizar as configurações do sistema. Atualmente, temos strings de configuração espalhadas pelo código, o que dificulta manutenção e pode gerar inconsistências. Com esta mudança, caso seja necessário alterar o nome de um grupo, bastará modificar a constante em `settings.base` ao invés de procurar todas as ocorrências no código.

### Screenshots
N/A - Mudança apenas no backend sem impacto visual

### Quais são tickets relevantes?
- Issue #[número]: Centralizar configurações de grupos e permissões

### Referências
- [[Django Best Practices - Settings](https://docs.djangoproject.com/en/stable/topics/settings/#custom-default-settings)](https://docs.djangoproject.com/en/stable/topics/settings/#custom-default-settings)
- Padrão DRY (Don't Repeat Yourself) aplicado a configurações