### PR TITLE
Atualiza packtools versão 4.15.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,7 +88,7 @@ pysolr==3.9.0  # https://pypi.org/project/pysolr/
 # ------------------------------------------------------------------------------
 tornado>=6.5.2 # not directly required, pinned by Snyk to avoid a vulnerability 
 lxml==6.0.2  # https://github.com/lxml/lxml
-git+https://git@github.com/scieloorg/packtools@4.14.0#egg=packtools
+git+https://git@github.com/scieloorg/packtools@4.15.0#egg=packtools
 
 # pymongo
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### O que esse PR faz?
Corrige:

```
Traceback (most recent call last):
2026-02-24T14:50:09.980506000Z   File "/app/manage.py", line 31, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.11/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/usr/local/lib/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.11/site-packages/django/apps/registry.py", line 116, in populate
    app_config.import_models()
2026-02-24T14:50:09.982551290Z   File "/usr/local/lib/python3.11/site-packages/django/apps/config.py", line 269, in import_models
    self.models_module = import_module(models_module_name)
2026-02-24T14:50:09.983645726Z                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-24T14:50:09.987067032Z   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
2026-02-24T14:50:09.987134470Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-02-24T14:50:09.987152200Z   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
2026-02-24T14:50:09.987169071Z   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
2026-02-24T14:50:09.987184783Z   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
2026-02-24T14:50:09.987201853Z   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
2026-02-24T14:50:09.987217343Z   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/app/article/models.py", line 18, in <module>
    from packtools.sps.formats import crossref, pmc, pubmed
2026-02-24T14:50:09.987700008Z   File "/usr/local/lib/python3.11/site-packages/packtools/__init__.py", line 11, in <module>
2026-02-24T14:50:09.989025743Z     from .domain import XMLValidator, HTMLGenerator
  File "/usr/local/lib/python3.11/site-packages/packtools/domain.py", line 20, in <module>
    from . import utils, catalogs, style_errors, exceptions
  File "/usr/local/lib/python3.11/site-packages/packtools/utils.py", line 23, in <module>
    from packtools import catalogs, exceptions
  File "/usr/local/lib/python3.11/site-packages/packtools/catalogs/__init__.py", line 136, in <module>
    sys.modules[__name__] = PluggableModule()
                            ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/packtools/catalogs/__init__.py", line 121, in __init__
    self.catalog = CatalogLoader().load('packtools_catalog',
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/packtools/catalogs/__init__.py", line 115, in load
    plugin = self._load_plugin_if_exists(name) or default
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/packtools/catalogs/__init__.py", line 98, in _load_plugin_if_exists
2026-02-24T14:50:09.996951825Z     from pkg_resources import iter_entry_points
2026-02-24T14:50:09.996985760Z ModuleNotFoundError: No module named 'pkg_resources'
```

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
Problema ocorre ao subir. container

#### Algum cenário de contexto que queira dar?
A partir de alguma release de setuptools superior a 80.10.2 conflita com pkg_resources que é um dependência do packtools

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
