### PR TITLE
Fix improve oai pmh metadata quality for agris ap compliance

### DIFF
--- a/article/search_indexes.py
+++ b/article/search_indexes.py
@@ -447,13 +447,18 @@ class ArticleOAIIndex(indexes.SearchIndex, indexes.Indexable):
             return set([title.plain_text for title in obj.titles.all()])
 
     def prepare_creator(self, obj):
-        """The list of authors is the contrib_persons on the models."""
-        if obj.contrib_persons.exists():
-            return set([
-                person.names
-                for person in obj.contrib_persons.all()
-                if person.names
-            ])
+        if not obj.contrib_persons.exists():
+            return None
+        result = set()
+        for person in obj.contrib_persons.all():
+            if person.last_name:
+                suffix = f" {person.suffix}" if person.suffix else ""
+                given = f", {person.given_names}" if person.given_names else ""
+                result.add(f"{person.last_name}{suffix}{given}")
+            elif person.names:
+                # fallback: nome completo sem inversão
+                result.add(person.names)
+        return result or None
 
     def prepare_collab(self, obj):
         """This is the instituional author."""
@@ -519,8 +524,9 @@ class ArticleOAIIndex(indexes.SearchIndex, indexes.Indexable):
         return idents
 
     def prepare_license(self, obj):
-        if obj.license and obj.license.license_type:
-            return [obj.license.license_type]
+        if obj.license and obj.license.url:
+            return [obj.license.url]
+        return None
 
     def prepare_sources(self, obj):
         # property no article.
@@ -534,5 +540,6 @@ class ArticleOAIIndex(indexes.SearchIndex, indexes.Indexable):
         return Article
 
     def index_queryset(self, using=None):
-        return self.get_model().objects.filter(is_classic_public=True)
+        # return self.get_model().objects.filter(is_classic_public=True)
+        return self.get_model().objects.all()
 

--- a/article/search_indexes.py
+++ b/article/search_indexes.py
@@ -540,6 +540,6 @@ class ArticleOAIIndex(indexes.SearchIndex, indexes.Indexable):
         return Article
 
     def index_queryset(self, using=None):
-        # return self.get_model().objects.filter(is_classic_public=True)
-        return self.get_model().objects.all()
+        return self.get_model().objects.filter(is_classic_public=True)
+        # return self.get_model().objects.all()
 

--- a/article/templates/search/indexes/article/article_compile.txt
+++ b/article/templates/search/indexes/article/article_compile.txt
@@ -10,20 +10,23 @@
             <element name="none">
             {% for title in object.titles.all %}
                 <field name="value">{{ title.plain_text }}</field>
-            {% endfor%}
+            {% endfor %}
             </element>
         </element>
-        <element name="creator">
-            <element name="none">
+
+        <!-- C1: creator via contrib_persons com afiliação -->
+        <element name="contributor">
+            <element name="author">
             {% for person in object.contrib_persons.all %}
-                {% if person.orcid %}
-                    <field name="value" orcid="{{person.orcid}}">{{person.names}}</field>
-                {% else %}
-                    <field name="value">{{person.names}}</field>
+                {% if person.last_name %}
+                    <field name="value" {% if person.orcid %}orcid="{{ person.orcid }}"{% endif %}>{{ person.last_name }}{% if person.suffix %} {{ person.suffix }}{% endif %}{% if person.given_names %}, {{ person.given_names }}{% endif %}</field>
+                {% elif person.names %}
+                    <field name="value" {% if person.orcid %}orcid="{{ person.orcid }}"{% endif %}>{{ person.names }}</field>
                 {% endif %}
             {% endfor %}
             </element>
         </element>
+
         <element name="subject">
             <element name="none">
             {% for kwd in object.keywords.all %}
@@ -31,74 +34,110 @@
             {% endfor %}
             </element>
         </element>
+
+        <!-- C2: abstract via plain_text em vez de __str__ -->
         <element name="description">
-            <element name="none">
+            <element name="abstract">
             {% for abs in object.abstracts.all %}
-                <field name="value">{{ abs }}</field>
+                <element>
+                    <field name="value">{{ abs.plain_text }}</field>
+                </element>
             {% endfor %}
-            <field name="value"/>
             </element>
         </element>
-      <element name="date">
-         <element name="none">
-            <field name="value">{{ object.updated|date:"c" }}</field>
-         </element>
-      </element>
-      <element name="type">
-         <element name="none">
-            <field name="value">{{ object.article_type }}</field>
-         </element>
-      </element>
-      <element name="identifier">
-         <element name="none">
 
-            {% for doi in object.doi.all %}
-                <field name="value">{{ doi.value }}</field>
-            {% endfor %}
 
+        <!-- C3: data de publicação em vez de updated -->
+        <element name="date">
+            <element name="issued">
+                <element>
+                    <field name="value">{{ object.pub_date }}</field>
+                </element>
+            </element>
+        </element>
+
+        <element name="type">
+            <element name="none">
+                <field name="value">{{ object.article_type }}</field>
+            </element>
+        </element>
+
+        <!-- C4: identificadores com sub-elementos por tipo -->
+        <element name="identifier">
+            <element name="none">
                 <field name="value">{{ object.pid_v2 }}</field>
                 <field name="value">{{ object.pid_v3 }}</field>
-
+            </element>
+            {% for doi in object.doi.all %}
+            <element name="doi">
+                <element>
+                    <field name="value">{{ doi.value }}</field>
+                </element>
+            </element>
+            {% endfor %}
+            <element name="uri">
             {% for collection in object.collections %}
                 {% for lang in object.languages.all %}
-                    <field name="value">http://{{collection.domain}}/scielo.php?script=sci_arttext&amp;pid={{object.pid_v2}}&amp;tlng={{lang.code2}}</field>
+                <element>
+                    <field name="value">https://{{ collection.domain }}/scielo.php?script=sci_arttext&amp;pid={{ object.pid_v2 }}&amp;tlng={{ lang.code2 }}</field>
+                </element>
                 {% endfor %}
             {% endfor %}
-                    
-         </element>
-      </element>
-      <element name="language">
-         <element name="none">
-            {% for lang in object.languages.all %}
-                <field name="value">{{ lang.code2 }}</field>
-            {% endfor %}
-         </element>
-      </element>
-      <element name="rights">
-         <element name="none">
-            {% for lic in object.license.all %}
-                <field name="value">{{ lic }}</field>
-            {% endfor %}
-         </element>
-      </element>
-      <element name="source">
-         <element name="none">
-            <field name="value">{{ object.source }}</field>
-         </element>
-      </element>
-    
-      <element name="publisher">
-         <element name="none">
+            </element>
+        </element>
+
+        <element name="language">
+            <element name="iso">
+                {% for lang in object.languages.all %}
+                <element>
+                    <field name="value">{{ lang.code2 }}</field>
+                </element>
+                {% endfor %}
+            </element>
+        </element>
+
+        <!-- C5: rights via ForeignKey, não .all() -->
+        <element name="rights">
+            <element name="none">
+            {% if object.license and object.license.url %}
+                <field name="value">{{ object.license.url }}</field>
+            {% endif %}
+            </element>
+        </element>
+
+        <!-- C6: source via journal -->
+        <element name="source">
+            <element name="none">
+            {% if object.journal %}
+                <field name="value">{{ object.journal.title }}{% if object.pub_date_year %}, {{ object.pub_date_year }}{% endif %}</field>
+            {% endif %}
+            </element>
+        </element>
+
+        <element name="publisher">
+            <element name="none">
             {% for publisher_name in object.publisher_names %}
-            <field name="value">{{ publisher_name }}</field>
+                <field name="value">{{ publisher_name }}</field>
             {% endfor %}
-         </element>
-      </element>
-      <element name="format">
-         <element name="none">
-            <field name="value">text/html</field>
-         </element>
-      </element>
+            </element>
+        </element>
+
+        <element name="format">
+            <element name="none">
+                <field name="value">text/html</field>
+            </element>
+        </element>
+
+        <element name="relation">
+            <element name="ispartof">
+                <element>
+                {% if object.journal %}
+                    <field name="value">{{ object.journal.title }}</field>
+                {% endif %}
+                </element>
+            </element>
+        </element>
+
     </element>
     <element name="bundles"/>
     <element name="others">
@@ -111,4 +150,3 @@
         <field name="name"/>
     </element>
 </metadata>
-

--- a/core/models.py
+++ b/core/models.py
@@ -399,7 +399,7 @@ class RawOrganizationMixin(models.Model):
                 institution=institution,
                 user=user,
             )
-        
+
     @classmethod
     def create(cls, raw_text, initial_date=None, final_date=None, user=None, institution=None):
         history = cls()
@@ -446,7 +446,7 @@ class RawOrganizationMixin(models.Model):
 class OrganizationNameMixin(models.Model):
     """
     Mixin that provides organization name and acronym fields.
-    
+
     Fields:
         name: The organization's full name
         acronym: The organization's acronym
@@ -483,7 +483,7 @@ class OrganizationNameMixin(models.Model):
 class VisualIdentityMixin(models.Model):
     """
     Mixin that provides visual identity fields for organizations.
-    
+
     Fields:
         logo: The organization's logo image
         url: The organization's website URL
@@ -645,10 +645,18 @@ class License(CommonControlField):
             return cls.get(license_type=license_type, version=version)
         except cls.DoesNotExist:
             return cls.create(user, license_type, version)
-        
+
     @property
     def url(self):
-        return f"https://creativecommons.org/licenses/{self.license_type}/{self.version or '4.0'}/"
+        """Reconstrói a URL CC a partir do license_type no formato 'CC {CODE} {VERSION}'"""
+        if not self.license_type:
+            return None
+        parts = self.license_type.split()
+        if len(parts) == 3 and parts[0].upper() == "CC":
+            code = parts[1].lower()  # "BY" → "by", "BY-NC" → "by-nc"
+            version = parts[2]  # "4.0"
+            return f"https://creativecommons.org/licenses/{code}/{version}/"
+        return None
 
     @property
     def data(self):
@@ -743,7 +751,7 @@ class LicenseStatement(CommonControlField):
     def parse_url(url):
         """
         Parse Creative Commons license URL.
-        
+
         Exemplos de URLs:
         - https://creativecommons.org/licenses/by/4.0/
         - https://creativecommons.org/licenses/by-nc/3.0/br/
@@ -754,32 +762,32 @@ class LicenseStatement(CommonControlField):
 
         url = url.lower().rstrip("/")
         url_parts = [p for p in url.split("/") if p]
-        
+
         if not url_parts:
             return {}
 
         license_types = dict(choices.LICENSE_TYPES)
-        
+
         for i, part in enumerate(url_parts):
             if part not in license_types:
                 continue
-                
+
             license_type = part
             remaining = url_parts[i + 1:]
             license_version = None
             license_language = None
-            
+
             if remaining:
                 version_candidate = remaining[0]
                 if all(c.isdigit() or c == "." for c in version_candidate):
                     license_version = version_candidate
                     remaining = remaining[1:]
-            
+
             if remaining:
                 lang_candidate = remaining[0]
                 if lang_candidate.isalpha() and 2 <= len(lang_candidate) <= 3:
                     license_language = lang_candidate
-            
+
             return {
                 "license_type": license_type,
                 "license_version": license_version,
@@ -853,7 +861,7 @@ class BaseHistory(models.Model):
         if self.initial_date:
             return self.initial_date.isoformat()
         return None
-    
+
     @property
     def final_date_isoformat(self):
         if self.final_date:
@@ -1305,7 +1313,7 @@ class BaseLegacyRecord(CommonControlField):
         obj.creator = user
         obj.save()
         return obj
-    
+
     @classmethod
     def create_or_update(cls, pid, collection, data=None, user=None, url=None, status=None, processing_date=None, force_update=None, new_record=None):
         try:


### PR DESCRIPTION
### Descrição do PR
Corrige a geração de metadados OAI-PMH no SciELO Core para conformidade
com o AGRIS Application Profile. Os problemas foram identificados por análise
comparativa entre o XML interno XOAI (`item.compile`) e a saída `oai_dc_agris`
gerada pelo `lareferencia-oai-pmh`.
 
As correções afetam o template de compilação do registro XOAI, o índice
de busca OAI e o modelo de licença.
 
---
 
### Arquivo 1: `article/templates/search/indexes/article/article_compile.txt`
 
#### Commit
```
fix(compile): fix OAI-PMH record template for AGRIS AP compliance
 
Corrige múltiplos problemas identificados na saída oai_dc_agris:
 
- dc:description: {{ abs }} chamava __str__ de DocumentAbstract,
  retornando "[None | en] Abstract..." em vez do texto puro.
  Corrigido para {{ abs.plain_text }} com sub-elemento 'abstract'
  e wrapper <element> conforme estrutura esperada pelo crosswalk.
 
- dc:date: object.updated (timestamp de modificação Django) era
  emitido como data de publicação. Corrigido para object.pub_date
  sob sub-elemento 'issued', alinhado com dc.date.issued do crosswalk.
 
- dc:identifier: todos os identificadores estavam sob 'none',
  impedindo o crosswalk de qualificá-los por tipo. Reestruturado
  com sub-elementos nomeados: 'doi' e 'uri'. Identificadores internos
  (pid_v2, pid_v3) mantidos em 'none'.
 
- dc:rights: object.license é ForeignKey, não M2M. A chamada .all()
  nunca executava, resultando em dc:rights sempre vazio.
  Corrigido para acesso direto via object.license.url.
 
- dc:source: object.source retornava vazio para a maioria dos
  registros. Substituído por construção explícita a partir de
  object.journal.title e object.pub_date_year.
 
- dc:relation: adicionado via journal.title para indicar o periódico
  de origem do artigo, conforme recomendação AGRIS AP.
 
- dc:contributor.author: estrutura alterada de dc.creator.none para
  dc.contributor.author, alinhada com o crosswalk. Nome do autor
  emitido no formato "Sobrenome, Nome" usando last_name e given_names
  do modelo ContribPerson. Mantém fallback para person.names quando
  last_name não está disponível.
 
Ref: AGRIS AP — seção 4.2 Creator
     https://www.fao.org/4/ae909e/ae909e05.htm
Ref: AGRIS AP — seção 4.6 Description
Ref: AGRIS AP — seção 4.7 Date
Ref: AGRIS AP — seção 4.8 Identifier
Ref: AGRIS AP — seção 4.11 Rights
Ref: AGRIS AP — seção 4.13 Source
```
 
Alterações por correção:
 
| Campo | Problema | Correção |
|---|---|---|
| `dc:description` | `__str__` com prefixo `[None \| en]` | `abs.plain_text` + sub-elemento `abstract` |
| `dc:date` | `object.updated` (timestamp interno) | `object.pub_date` sob `issued` |
| `dc:identifier` | tudo em `none` | sub-elementos `doi`, `uri` |
| `dc:rights` | `.all()` em ForeignKey | `object.license.url` direto |
| `dc:source` | `object.source` vazio | `journal.title + pub_date_year` |
| `dc:relation` | ausente | adicionado via `journal.title` |
| `dc:creator` | `none` sem inversão de nome | `contributor.author` com `Sobrenome, Nome` |
 
---
 
### Arquivo 2: `article/search_indexes.py`
 
#### Commit
```
fix(search_indexes): fix prepare_license and prepare_creator
                     in ArticleOAIIndex for AGRIS AP compliance
 
prepare_license: retornava o código interno "CC BY 4.0" em vez da
URL da licença Creative Commons. Refatorado para usar License.url,
que reconstrói a URL correta a partir do license_type.
 
prepare_creator: retornava person.names (nome completo sem inversão,
em caixa alta). O AGRIS AP exige o formato "Sobrenome, Nome" para
autores pessoais. Corrigido para construir o nome a partir dos campos
separados last_name, given_names e suffix do modelo ContribPerson.
Mantém fallback para person.names quando last_name não está disponível.
 
Ref: AGRIS AP — seção 4.2 Creator
     https://www.fao.org/4/ae909e/ae909e05.htm
Ref: AGRIS AP — seção 4.11 Rights
```
 
Alterações:
```python
# prepare_license — ANTES
def prepare_license(self, obj):
    if obj.license and obj.license.license_type:
        return [obj.license.license_type]
 
# prepare_license — DEPOIS
def prepare_license(self, obj):
    if obj.license and obj.license.url:
        return [obj.license.url]
    return None
 
# prepare_creator — ANTES
def prepare_creator(self, obj):
    if obj.contrib_persons.exists():
        return set([
            person.names
            for person in obj.contrib_persons.all()
            if person.names
        ])
 
# prepare_creator — DEPOIS
def prepare_creator(self, obj):
    if not obj.contrib_persons.exists():
        return None
    result = set()
    for person in obj.contrib_persons.all():
        if person.last_name:
            suffix = f" {person.suffix}" if person.suffix else ""
            given = f", {person.given_names}" if person.given_names else ""
            result.add(f"{person.last_name}{suffix}{given}")
        elif person.names:
            result.add(person.names)
    return result or None
```
 
---
 
### Arquivo 3: `core/models.py`
 
#### Commit
```
fix(models): fix License.url to correctly reconstruct CC license URL
 
A property License.url existia mas gerava URLs inválidas porque usava
license_type ("CC BY 4.0") diretamente no path da URL.
 
O campo license_type segue o formato "CC {CODE} {VERSION}" com
version=None (ex.: "CC BY 4.0", "CC BY-NC 4.0", "CC BY-SA 4.0").
 
Corrigido para parsear o formato e reconstruir a URL:
  "CC BY 4.0"    → https://creativecommons.org/licenses/by/4.0/
  "CC BY-NC 4.0" → https://creativecommons.org/licenses/by-nc/4.0/
  "CC BY-SA 4.0" → https://creativecommons.org/licenses/by-sa/4.0/
```
 
Alterações:
```python
# ANTES
@property
def url(self):
    return f"https://creativecommons.org/licenses/{self.license_type}/{self.version or '4.0'}/"
 
# DEPOIS
@property
def url(self):
    """Reconstrói a URL CC a partir do license_type no formato 'CC {CODE} {VERSION}'"""
    if not self.license_type:
        return None
    parts = self.license_type.split()
    if len(parts) == 3 and parts[0].upper() == "CC":
        code = parts[1].lower()
        version = parts[2]
        return f"https://creativecommons.org/licenses/{code}/{version}/"
    return None
```
 
---
 
## Checklist de revisão — PR 2
 
- [ ] `rebuild_index` executado após alterações no `search_indexes.py`
- [ ] `GetRecord` testado com artigo que tem `contrib_persons`, `license` e `abstracts` populados
- [ ] `dc:creator` no formato `Sobrenome, Nome` confirmado na saída
- [ ] `dc:rights` com URL CC completa confirmada na saída
- [ ] `dc:description` sem prefixo `[None | en]` confirmado na saída
- [ ] `dc:date` com apenas `dcterms:dateIssued` confirmado na saída
- [ ] `License.url` testado com os três tipos (`CC BY`, `CC BY-NC`, `CC BY-SA`)