### PR TITLE
Limita conexoes Redis idle

### DIFF
--- a/compose/production/django/entrypoint
+++ b/compose/production/django/entrypoint
@@ -7,7 +7,7 @@ set -o nounset
 
 
 # N.B. If only .env files supported variable expansion...
-export CELERY_BROKER_URL="${REDIS_URL}"
+export CELERY_BROKER_URL="${CELERY_BROKER_URL:-${REDIS_URL}}"
 
 
 if [ -z "${POSTGRES_USER}" ]; then

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -490,6 +490,11 @@ if USE_TZ:
 CELERY_BROKER_URL = env("CELERY_BROKER_URL")
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# Redis broker/backend connection pools are per process. Keep them bounded so
+# web, worker, beat and monitoring replicas cannot accumulate thousands of idle
+# sockets after traffic or pod churn.
+CELERY_BROKER_POOL_LIMIT = env.int("CELERY_BROKER_POOL_LIMIT", default=5)
+CELERY_REDIS_MAX_CONNECTIONS = env.int("CELERY_REDIS_MAX_CONNECTIONS", default=20)
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content
 CELERY_ACCEPT_CONTENT = ["json"]
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_serializer

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -22,6 +22,18 @@ CACHES = {
         "LOCATION": "redis://redis:6379",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
+            "CONNECTION_POOL_KWARGS": {
+                "max_connections": env.int("REDIS_CACHE_MAX_CONNECTIONS", default=20),
+                "timeout": env.int("REDIS_CACHE_POOL_TIMEOUT", default=2),
+                "health_check_interval": env.int(
+                    "REDIS_HEALTH_CHECK_INTERVAL", default=30
+                ),
+            },
+            "SOCKET_CONNECT_TIMEOUT": env.int(
+                "REDIS_SOCKET_CONNECT_TIMEOUT", default=2
+            ),
+            "SOCKET_TIMEOUT": env.int("REDIS_SOCKET_TIMEOUT", default=2),
         }
     }
 }

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -30,6 +30,18 @@ CACHES = {
         "LOCATION": env("REDIS_URL"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
+            "CONNECTION_POOL_KWARGS": {
+                "max_connections": env.int("REDIS_CACHE_MAX_CONNECTIONS", default=20),
+                "timeout": env.int("REDIS_CACHE_POOL_TIMEOUT", default=2),
+                "health_check_interval": env.int(
+                    "REDIS_HEALTH_CHECK_INTERVAL", default=30
+                ),
+            },
+            "SOCKET_CONNECT_TIMEOUT": env.int(
+                "REDIS_SOCKET_CONNECT_TIMEOUT", default=2
+            ),
+            "SOCKET_TIMEOUT": env.int("REDIS_SOCKET_TIMEOUT", default=2),
             # Mimicing memcache behavior.
             # https://github.com/jazzband/django-redis#memcached-exceptions-behavior
             "IGNORE_EXCEPTIONS": True,


### PR DESCRIPTION
#### O que esse PR faz?
Configura django-redis para usar BlockingConnectionPool com limite de conexoes, timeout de pool, socket timeouts e health check em local e producao.

Adiciona limites para pools Redis usados pelo Celery broker/backend para reduzir acumulo de sockets idle por processo.

Preserva CELERY_BROKER_URL quando definido no entrypoint de producao, permitindo separar broker/cache sem sobrescrever com REDIS_URL.

#### Onde a revisão poderia começar?
Apliquei uma correção em:
config/settings/production.py (line 27): django-redis agora usa BlockingConnectionPool, com REDIS_CACHE_MAX_CONNECTIONS, timeout de pool, socket timeout e health check.

config/settings/local.py (line 16): mesma configuração para local.

config/settings/base.py (line 490): limites para pools Redis do Celery: CELERY_BROKER_POOL_LIMIT=5 e CELERY_REDIS_MAX_CONNECTIONS=20 por padrão.

compose/production/django/entrypoint (line 10): não força mais CELERY_BROKER_URL=REDIS_URL se você definir CELERY_BROKER_URL explicitamente.

#### Como este poderia ser testado manualmente?
Validei com Docker, sim.

O que passou:

docker compose -f local.yml config: Compose parseou ok. Só apareceu o aviso já esperado de version obsoleto.
Build da imagem local scielo_core_local_django: passou.
Redis local subiu e respondeu.
config.settings.local: cache.set/get funcionou contra Redis.
config.settings.production: validei a parte Redis/Celery sem django.setup(), porque a imagem local não tem anymail, dependência de produção.
O pool aplicado ficou correto:
pool_class=BlockingConnectionPool
max_connections=20
pool_timeout=2
health_check_interval=30
celery_broker_pool_limit=5
celery_redis_max_connections=20
Sintaxe do /entrypoint: bash -n /entrypoint passou.
redis-cli INFO clients após os testes mostrou connected_clients:1, sem conexões presas pelos containers one-shot.
Parei o Redis local que eu tinha subido para a validação.
Resumo: as mudanças estão funcionais no Docker e os limites de pool estão efetivamente sendo aplicados.

### Referências
Correção elabora pelo codex gpt

