### PR TITLE
Correção JournalPage: related manager não iterável no contact_footer

### DIFF
--- a/journalpage/templates/journalpage/includes/contact_footer.html
+++ b/journalpage/templates/journalpage/includes/contact_footer.html
@@ -28,7 +28,7 @@
           <span>
             {% trans 'Acompanhe os números deste periódico no seu leitor de RSS' %}
           </span>
-            {% for sn in journal.social_networks %}
+            {% for sn in journal.social_networks.all %}
                 <a href="{{sn.account}}" data-toggle="tooltip" title="{{sn.network|title}}">
                     <span
                         {% if network == 'twitter' %}


### PR DESCRIPTION
#### O que esse PR faz?
Evita erro 500 na JournalPage iterando social_networks.all no template do footer.


#### Como este poderia ser testado manualmente?
Acessar a página informativa do periódico através do butão na listagem do itens do modelo Journal


