### PR TITLE
Corrige a condição de reaproveitar registros de UnexpectedEvent

### DIFF
--- a/tracker/models.py
+++ b/tracker/models.py
@@ -170,6 +170,11 @@ class UnexpectedEvent(models.Model):
         (incluindo o par None, None). Se houver múltiplos, retorna
         o mais recente considerando updated e, em seguida, created.
         """
+        if not item or not action:
+            # evita que UnexpectedEvent sejam sobrescritos por não terem item ou action
+            # antes de serem avaliados
+            return
+
         qs = cls.objects.filter(item=item, action=action).order_by(
             "-updated", "-created"
         )


### PR DESCRIPTION
## O que esse PR faz?

Este PR ajusta o método de busca de registros na model `UnexpectedEvent` para interromper a execução (*early return*) caso o `item` ou a `action` não sejam informados.

**Problema resolvido:** Anteriormente, quando uma chamada passava `item` ou `action` nulos/falsy, a busca tentava encontrar registros existentes filtrando por `(item=None, action=None)`. Isso fazia com que novos eventos inesperados e genéricos (sem item ou ação definidos) agrupassem-se e sobrescrevessem eventos antigos que também possuíam `(None, None)`, em vez de registrarem cada evento de forma individual.

## Onde a revisão poderia começar?

A revisão deve começar diretamente no arquivo alterado:

* `tracker/models.py` (no método de busca/avaliação dentro do modelo `UnexpectedEvent`).

## Como este poderia ser testado manualmente?

1. Abra o shell do Django (`python manage.py shell`).
2. Execute o método de busca da model `UnexpectedEvent` passando `item=None` ou `action=None`.
3. Verifique que o método retorna `None` imediatamente sem realizar a consulta de filtro `(None, None)` no banco de dados.
4. Tente registrar dois eventos sequenciais sem `item` ou `action` e confirme que ambos foram salvos como instâncias separadas no banco, sem que o segundo sobrescreva o primeiro.
5. Faça uma chamada passando `item` e `action` válidos e confirme que o comportamento de buscar e reutilizar/atualizar o registro existente continua funcionando normalmente.

## Algum cenário de contexto que queira dar?

Eventos do tipo `UnexpectedEvent` nem sempre possuem um `item` ou `action` mapeados no momento em que ocorrem. Permitir que o filtro rodasse com valores nulos causava perda de histórico de eventos genéricos, pois o sistema entendia que "qualquer evento sem item/action" era uma atualização do evento anterior que também não tinha esses dados.

## Screenshots

N/A (alteração puramente de regra de negócio/back-end).

## Quais são os tickets relevantes?

* #[INSIRA_O_NUMERO_DO_TICKET]

## Referências

* Documentação do ORM do Django sobre filtragem com valores `None`/`NULL`.

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**

* [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
* [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**

* [ ] Sim — descreva o que mudou e por quê:
* [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**

* [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
* [ ] Verificado e aprovado
* [ ] Pendente / vulnerabilidade aceita com justificativa:


* [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**

* [x] Sim — link do job: [INSIRA_O_LINK_DO_JOB_AQUI]
* [ ] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**

* [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
* [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**

* [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
* [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**

* [x] Não, nenhum segredo foi commitado
* [ ] Sim (bloquear merge e corrigir antes de prosseguir)